### PR TITLE
Element has inner text when it contains svg 

### DIFF
--- a/lib/rangy-textrange.js
+++ b/lib/rangy-textrange.js
@@ -637,6 +637,12 @@
                         return true;
                     }
                 }
+                // Ensure that a block element containing a <svg> is considered to have inner text
+                // as otherwise it will crash IE11
+                var svgs = el.getElementsByTagName("svg");
+                if (svgs.length) {
+                    return true;
+                }
                 return this.hasInnerText();
             }, "node"),
 

--- a/src/modules/rangy-textrange.js
+++ b/src/modules/rangy-textrange.js
@@ -629,6 +629,14 @@ rangy.createModule("TextRange", ["WrappedSelection"], function(api, module) {
                     return true;
                 }
             }
+
+            // Ensure that a block element containing a <svg> is considered to have inner text
+            // as otherwise it will crash IE11
+            var svgs = el.getElementsByTagName("svg");
+            if (svgs.length) {
+                return true;
+            }
+
             return this.hasInnerText();
         }, "node"),
 


### PR DESCRIPTION
Cause it's not a good idea to call `hasInnerText` on element which contains `svg` somewhere in IE11.

This fixes issue when clicking _EDIT NOTE_ freezes the browser when note contains snippets on the last line near the end of the note.
